### PR TITLE
Split package CI and action self tests

### DIFF
--- a/.github/workflows/action-self-test.yaml
+++ b/.github/workflows/action-self-test.yaml
@@ -1,4 +1,4 @@
-name: build-and-test
+name: Action self-test
 
 on:
   push:
@@ -9,30 +9,12 @@ on:
       - '**'
   schedule:
     - cron: '0 2 * * *'
+  workflow_dispatch:
 
 permissions: {}
 
 jobs:
-  check-build:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-      - name: Install dependencies
-        run: npm install
-      - name: Rebuild dist
-        run: npm run package
-      - name: Check for uncommitted build changes
-        run: |
-          if ! git diff --exit-code dist/; then
-            echo "::error::dist/ is out of date. Run 'npm run all' locally and commit the result."
-            exit 1
-          fi
-
-  build-and-test:
-    needs: check-build
+  action-test:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -42,8 +24,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '26'
+          cache: npm
       - name: Install dependencies
-        run: npm install
+        run: npm ci
       - name: Build
         run: npm run all
       - name: Publish Test Report
@@ -83,8 +70,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: always()
+
   standard-reports-test:
-    needs: build-and-test
+    needs: action-test
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -99,7 +87,7 @@ jobs:
           annotate: false
         if: always()
   github-report-test:
-    needs: build-and-test
+    needs: action-test
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -117,7 +105,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: always()
   detailed-reports-test:
-    needs: build-and-test
+    needs: action-test
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -136,7 +124,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: always()
   failed-reports-test:
-    needs: build-and-test
+    needs: action-test
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -155,7 +143,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: always()
   flaky-reports-test:
-    needs: build-and-test
+    needs: action-test
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -173,7 +161,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: always()
   ai-reports-test:
-    needs: build-and-test
+    needs: action-test
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -189,7 +177,7 @@ jobs:
           annotate: false
         if: always()
   skipped-reports-test:
-    needs: build-and-test
+    needs: action-test
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -204,7 +192,7 @@ jobs:
           annotate: false
         if: always()
   suite-reports-test:
-    needs: build-and-test
+    needs: action-test
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -220,7 +208,7 @@ jobs:
           annotate: false
         if: always()
   commit-reports-test:
-    needs: build-and-test
+    needs: action-test
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -235,7 +223,7 @@ jobs:
           annotate: false
         if: always()
   custom-reports-test:
-    needs: build-and-test
+    needs: action-test
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -251,7 +239,7 @@ jobs:
           annotate: false
         if: always()
   community-reports-test:
-    needs: build-and-test
+    needs: action-test
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -267,7 +255,7 @@ jobs:
           annotate: false
         if: always()
   previous-reports-test:
-    needs: build-and-test
+    needs: action-test
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -276,8 +264,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '26'
+          cache: npm
       - name: Install dependencies
-        run: npm install
+        run: npm ci
       - name: Modify reports
         run: npm run modify-reports
       - name: Reports Requiring Previous
@@ -294,7 +287,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: always()
   report-order-test:
-    needs: build-and-test
+    needs: action-test
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -302,8 +295,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '26'
+          cache: npm
       - name: Install dependencies
-        run: npm install
+        run: npm ci
       - name: Modify reports
         run: npm run modify-reports
       - name: Custom Report Order
@@ -319,7 +317,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: always()
   collapse-large-reports-test:
-    needs: build-and-test
+    needs: action-test
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -327,8 +325,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '26'
+          cache: npm
       - name: Install dependencies
-        run: npm install
+        run: npm ci
       - name: Modify reports
         run: npm run modify-reports
       - name: Collapse Large Reports Test
@@ -343,7 +346,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: always()
   junit-to-ctrf-test:
-    needs: build-and-test
+    needs: action-test
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -351,8 +354,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '26'
+          cache: npm
       - name: Install dependencies
-        run: npm install
+        run: npm ci
       - name: Modify reports
         run: npm run modify-reports
       - name: JUnit to CTRF integration test
@@ -379,7 +387,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: always()
   file-reports-test:
-    needs: build-and-test
+    needs: action-test
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -387,8 +395,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '26'
+          cache: npm
       - name: Install dependencies
-        run: npm install
+        run: npm ci
       - name: Modify reports
         run: npm run modify-reports
       - name: File Reports Test

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,140 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CI: true
+
+permissions:
+  contents: read
+
+jobs:
+  quality:
+    name: Quality (lint/format)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '26'
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint:check
+
+      - name: Format check
+        run: npm run format:check
+
+  test-build:
+    name: Test + Build (Node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    needs: [quality]
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ['24', '26']
+
+    permissions:
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run package
+
+      - name: Publish Test Report
+        uses: ctrf-io/github-test-reporter@v1
+        with:
+          report-path: './ctrf/*.json'
+          summary-delta-report: true
+          github-report: true
+          failed-report: true
+          flaky-report: true
+          insights-report: true
+          fail-rate-report: true
+          flaky-rate-report: true
+          slowest-report: true
+          previous-results-report: true
+          upload-artifact: true
+          artifact-name: ctrf-test-report-node-${{ matrix.node }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: always() && hashFiles('ctrf/*.json') != ''
+
+  dist:
+    name: Dist rebuild validation
+    runs-on: ubuntu-latest
+    needs: [quality]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '26'
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Rebuild dist
+        run: npm run package
+
+      - name: Check for uncommitted build changes
+        run: |
+          if ! git diff --exit-code dist/; then
+            echo "::error::dist/ is out of date. Run 'npm run package' locally and commit the result."
+            exit 1
+          fi
+
+  security:
+    name: Security (deps audit)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '26'
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: npm audit (prod)
+        run: npm audit --omit=dev
+        continue-on-error: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
 				"teams-ctrf": "0.0.6"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "^2.4.16",
+				"@biomejs/biome": "2.4.16",
 				"@d2t/vitest-ctrf-json-reporter": "1.3.0",
 				"@types/adm-zip": "0.5.8",
 				"@types/node": "25.9.2",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 	"author": "Matthew Poulton-White",
 	"license": "MIT",
 	"devDependencies": {
-		"@biomejs/biome": "^2.4.16",
+		"@biomejs/biome": "2.4.16",
 		"@d2t/vitest-ctrf-json-reporter": "1.3.0",
 		"@types/adm-zip": "0.5.8",
 		"@types/node": "25.9.2",


### PR DESCRIPTION
## Summary
- add standard package CI in main.yaml with quality, test/build, dist validation, and security jobs
- split existing local uses: ./ action validation and report-mode checks into action-self-test.yaml
- run quality/security/dist validation on Node 26 and test/build on Node 24 and 26
- keep dist rebuild validation and CTRF reporting
